### PR TITLE
feat: remove serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "translatable"
@@ -234,7 +234,7 @@ version = "1.0.0"
 dependencies = [
  "quote",
  "thiserror",
- "toml",
+ "toml_edit",
  "translatable_proc",
  "translatable_shared",
  "trybuild",
@@ -249,7 +249,7 @@ dependencies = [
  "strum",
  "syn",
  "thiserror",
- "toml",
+ "toml_edit",
  "translatable_shared",
 ]
 
@@ -262,7 +262,7 @@ dependencies = [
  "strum",
  "syn",
  "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]

--- a/translatable/Cargo.toml
+++ b/translatable/Cargo.toml
@@ -22,5 +22,5 @@ translatable_shared = { version = "1", path = "../translatable_shared/" }
 
 [dev-dependencies]
 quote = "1.0.40"
-toml = "0.8.21"
+toml_edit = "0.22.26"
 trybuild = "1.0.104"

--- a/translatable/tests/unitary/translation_collection.rs
+++ b/translatable/tests/unitary/translation_collection.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use toml::Table;
+use toml_edit::DocumentMut;
 use translatable::Language;
 use translatable_shared::translations::collection::TranslationNodeCollection;
 use translatable_shared::translations::node::TranslationNode;
@@ -24,7 +24,7 @@ pub fn loads_and_finds_collection() {
             "a".into(),
             TranslationNode::try_from(
                 FILE_1
-                    .parse::<Table>()
+                    .parse::<DocumentMut>()
                     .expect("TOML to be parsed correctly."),
             )
             .expect("TOML to follow the translation rules."),
@@ -33,7 +33,7 @@ pub fn loads_and_finds_collection() {
             "b".into(),
             TranslationNode::try_from(
                 FILE_2
-                    .parse::<Table>()
+                    .parse::<DocumentMut>()
                     .expect("TOML to be parsed correctly."),
             )
             .expect("TOML to follow the translation rules."),

--- a/translatable_proc/Cargo.toml
+++ b/translatable_proc/Cargo.toml
@@ -17,5 +17,5 @@ quote = "1.0.38"
 strum = { version = "0.27.1", features = ["derive"] }
 syn = { version = "2.0.98", features = ["full"] }
 thiserror = "2.0.11"
-toml = "0.8.20"
+toml_edit = "0.22.26"
 translatable_shared = { version = "1", path = "../translatable_shared/" }

--- a/translatable_proc/src/data/config.rs
+++ b/translatable_proc/src/data/config.rs
@@ -11,8 +11,7 @@ use std::sync::OnceLock;
 
 use strum::EnumString;
 use thiserror::Error;
-use toml::Table;
-use toml::de::Error as TomlError;
+use toml_edit::{DocumentMut, TomlError};
 
 /// Configuration error enum.
 ///
@@ -213,7 +212,7 @@ pub fn load_config() -> Result<&'static MacroConfig, ConfigError> {
 
     let toml_content = read_to_string("./translatable.toml")
         .unwrap_or_default()
-        .parse::<Table>()?;
+        .parse::<DocumentMut>()?;
 
     macro_rules! config_value {
         ($env_var:expr, $key:expr, $default:expr) => {

--- a/translatable_proc/src/data/translations.rs
+++ b/translatable_proc/src/data/translations.rs
@@ -13,8 +13,7 @@ use std::io::Error as IoError;
 use std::sync::OnceLock;
 
 use thiserror::Error;
-use toml::Table;
-use toml::de::Error as TomlError;
+use toml_edit::{DocumentMut, TomlError};
 use translatable_shared::translations::collection::TranslationNodeCollection;
 use translatable_shared::translations::node::{TranslationNode, TranslationNodeError};
 
@@ -209,7 +208,7 @@ pub fn load_translations() -> Result<&'static TranslationNodeCollection, Transla
         .iter()
         .map(|path| {
             let table = read_to_string(path)?
-                .parse::<Table>()
+                .parse::<DocumentMut>()
                 .map_err(|err| TranslationDataError::ParseToml(err, path.clone()))?;
 
             Ok((path.clone(), TranslationNode::try_from(table)?))

--- a/translatable_shared/Cargo.toml
+++ b/translatable_shared/Cargo.toml
@@ -14,4 +14,4 @@ quote = "1.0.40"
 strum = { version = "0.27.1", features = ["derive", "strum_macros"] }
 syn = { version = "2.0.100", features = ["full"] }
 thiserror = "2.0.12"
-toml = "0.8.20"
+toml_edit = "0.22.26"


### PR DESCRIPTION
Switch from toml to toml_edit, this change removes the overhead of using
serde as a deserializer since toml_edit does not necessarily use serde
under the hood for this.


## Pre-submission Checklist

- [x] I've checked existing issues and pull requests
- [x] I've read the [Code of Conduct](https://github.com/FlakySL/translatable/blob/main/CODE_OF_CONDUCT.md)
- [x] I've [implemented tests](https://github.com/FlakySL/translatable/blob/main/translatable/tests/README.md) for my changes
- [x] I've listed all my changes in the `Changes` section

## Changes

- Replace `toml` crate with `toml_edit`

